### PR TITLE
add args and kwargs for run_in_thread and enable error handling in ma…

### DIFF
--- a/PyDrocsid/async_thread.py
+++ b/PyDrocsid/async_thread.py
@@ -1,6 +1,8 @@
 import asyncio
 import threading
 
+from functools import partial
+
 
 class Thread(threading.Thread):
     def __init__(self, func, loop):
@@ -15,8 +17,21 @@ class Thread(threading.Thread):
         return self._return
 
     def run(self):
-        self._return = self._func()
+        try:
+            self._return = True, self._func()
+        except Exception as e:
+            self._return = False, e
         self._loop.call_soon_threadsafe(self._event.set)
+
+
+async def run_in_thread(func, *args, **kwargs):
+    thread = Thread(partial(func, *args, **kwargs), asyncio.get_running_loop())
+    thread.start()
+    ok, result = await thread.wait()
+    if not ok:
+        raise result
+
+    return result
 
 
 async def run_in_thread(func):


### PR DESCRIPTION
Add the possibility to hand over args and kwargs in the `run_in_thread` method that will be passed into the function.
Add the possibility to handle error from the child thread in the parrent thread.