### PR TITLE
Remove skipcq

### DIFF
--- a/PyDrocsid/permission.py
+++ b/PyDrocsid/permission.py
@@ -149,7 +149,7 @@ class BasePermissionLevel(Enum):
         """Return whether this permission level is granted to a given member."""
 
         level: BasePermissionLevel = await self.get_permission_level(member)
-        return level.level >= self.level  # skipcq: PYL-W0143
+        return level.level >= self.level
 
     @property
     def check(self):


### PR DESCRIPTION
This was a false positive in our Python analyzer at DeepSource, but the problem was fixed a while ago.